### PR TITLE
fix: eslint jsdoc dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1280,25 +1280,17 @@
             }
         },
         "eslint-plugin-jsdoc": {
-            "version": "15.9.5",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-15.9.5.tgz",
-            "integrity": "sha512-OQOUf8Li9PRzULQG8Wi7QOd10aCZVAp/RkqOw0FYPT2j0F9lcPB21jBb6BLlWgR4F7XjdzbUmgVvhHYZGOWCVg==",
+            "version": "15.12.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-15.12.0.tgz",
+            "integrity": "sha512-oP+rOqAf54QLbJM3ECqhg8VOrcMfqBSbGSYCWAVX8cy0ySWXK1Z7yg8QylY1bedrRBAvxyWBxdgzDP6Uy6WoTg==",
             "dev": true,
             "requires": {
                 "comment-parser": "^0.6.2",
                 "debug": "^4.1.1",
-                "jsdoctypeparser": "5.0.1",
+                "jsdoctypeparser": "^5.1.1",
                 "lodash": "^4.17.15",
                 "object.entries-ponyfill": "^1.0.1",
                 "regextras": "^0.6.1"
-            },
-            "dependencies": {
-                "lodash": {
-                    "version": "4.17.15",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-                    "dev": true
-                }
             }
         },
         "eslint-plugin-node": {
@@ -3011,9 +3003,9 @@
             }
         },
         "jsdoctypeparser": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-5.0.1.tgz",
-            "integrity": "sha512-dYwcK6TKzvq+ZKtbp4sbQSW9JMo6s+4YFfUs5D/K7bZsn3s1NhEhZ+jmIPzby0HbkbECBe+hNPEa6a+E21o94w==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-5.1.1.tgz",
+            "integrity": "sha512-APGygIJrT5bbz5lsVt8vyLJC0miEbQf/z9ZBfTr4RYvdia8AhWMRlYgivvwHG5zKD/VW3d6qpChCy64hpQET3A==",
             "dev": true
         },
         "jsesc": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-html": "^6.0.0",
     "eslint-plugin-jest": "^22.17.0",
-    "eslint-plugin-jsdoc": "^15.9.5",
+    "eslint-plugin-jsdoc": "^15.12.0",
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-nuxt": "^0.4.3",
     "eslint-plugin-prettier": "^3.1.1",


### PR DESCRIPTION
# Description

Fixes `cannot find module comment-parser` error in dependant apps.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Link this repo to app
1. Run `npm run lint`
1. The lint should be successful.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Designer has reviewed the changes
