### PR TITLE
refactor: only require nesting or id for label/input association

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@boughtbymany/eslint-config-bbm",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boughtbymany/eslint-config-bbm",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Bought By Many ESLint Config",
   "homepage": "https://github.com/boughtbymany/eslint-config-bbm",
   "repository": "github:boughtbymany/eslint-config-bbm",

--- a/vue.js
+++ b/vue.js
@@ -16,6 +16,14 @@ module.exports = {
 
     // Priority C: Recommended (Minimizing Arbitrary Choices and Cognitive Overhead)
     'vue/no-v-html': 'off', // override for translation
+    'vue-a11y/label-has-for': [
+      2,
+      {
+        required: {
+          some: ['nesting', 'id'], // Only require nesting or id
+        },
+      },
+    ],
   },
   parserOptions: {
     parser: 'babel-eslint',

--- a/vue.js
+++ b/vue.js
@@ -20,7 +20,8 @@ module.exports = {
       2,
       {
         required: {
-          some: ['nesting', 'id'], // Only require nesting or id
+          // Only require one of nesting _or_ id.
+          some: ['nesting', 'id'],
         },
       },
     ],


### PR DESCRIPTION
The base vue-a11y ruleset requires an input to be nested AND have a matching label form attribute, which is a bit overkill and outdated.

I've updated the rule to only require one or the other, which covers the vast majority of modern screen readers and allows more flexibility in HTML structure.